### PR TITLE
Fixed issue with gpg keys being downloaded to wrong location

### DIFF
--- a/roles/sat6-repositories/tasks/main.yml
+++ b/roles/sat6-repositories/tasks/main.yml
@@ -33,6 +33,7 @@
   file:
     path: '/tmp/gpg-keys'
     state: directory
+  delegate_to: "{{ 'localhost' if fam_local else omit }}"
 
 - name: ensure GPG keys are present
   get_url:
@@ -41,6 +42,7 @@
   with_subelements:
   - "{{ custom_products }}"
   - repositories
+  delegate_to: "{{ 'localhost' if fam_local else omit }}"
 
 - name: ensure GPG keys exist
   katello_content_credential:


### PR DESCRIPTION
When operating locally (i.e. fam_local: True), gpg keys were still being downloaded to the remote server, causing "ensure GPG keys are present" to fail. Now fixed.